### PR TITLE
[Feat] 배송 생성 기능

### DIFF
--- a/logisix/delivery/build.gradle
+++ b/logisix/delivery/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 	implementation 'io.github.openfeign:feign-micrometer'
 	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 //	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	compileOnly 'org.projectlombok:lombok'

--- a/logisix/delivery/src/main/java/com/sparta/delivery/config/ObjectMapperConfig.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/config/ObjectMapperConfig.java
@@ -1,0 +1,14 @@
+package com.sparta.delivery.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/logisix/delivery/src/main/java/com/sparta/delivery/controller/DeliveryController.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/controller/DeliveryController.java
@@ -1,0 +1,25 @@
+package com.sparta.delivery.controller;
+
+import com.sparta.delivery.common.ApiResponse;
+import com.sparta.delivery.dto.CreateDeliveryRequest;
+import com.sparta.delivery.service.DeliveryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/deliveries")
+public class DeliveryController {
+
+    private final DeliveryService deliveryService;
+
+    @PostMapping
+    public ApiResponse createDelivery(
+            @RequestBody CreateDeliveryRequest request
+    ) {
+        return deliveryService.createDelivery(request);
+    }
+}

--- a/logisix/delivery/src/main/java/com/sparta/delivery/dto/CreateDeliveryRequest.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/dto/CreateDeliveryRequest.java
@@ -1,0 +1,11 @@
+package com.sparta.delivery.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record CreateDeliveryRequest(
+        @NotNull UUID orderId,
+        @NotNull UUID sourceHubId,
+        @NotNull UUID destinationId
+        ) { }

--- a/logisix/delivery/src/main/java/com/sparta/delivery/dto/HubRoute.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/dto/HubRoute.java
@@ -1,0 +1,13 @@
+package com.sparta.delivery.dto;
+
+import java.time.Duration;
+import java.util.UUID;
+
+public record HubRoute(
+        UUID hubRouteId,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        double estimatedDistance,
+        Duration estimateTime
+) {
+}

--- a/logisix/delivery/src/main/java/com/sparta/delivery/dto/KakaoRouteResponse.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/dto/KakaoRouteResponse.java
@@ -1,0 +1,23 @@
+package com.sparta.delivery.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.math.BigDecimal;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoRouteResponse(
+        Route[] routes
+    ) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Route(
+            Summary summary
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Summary(
+            BigDecimal distance,
+            BigDecimal duration
+    ) {
+    }
+}

--- a/logisix/delivery/src/main/java/com/sparta/delivery/entity/Deliveries.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/entity/Deliveries.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 @Getter
+@Setter
 public class Deliveries extends BaseEntity {
 
     @Id
@@ -39,7 +40,7 @@ public class Deliveries extends BaseEntity {
     @Column(nullable = false)
     private String recipientSlackAccount;
 
-    @Column(nullable = false)
+//    @Column(nullable = false)
     private LocalDateTime dispatchDeadline;
 
     private Integer totalSequence;
@@ -54,5 +55,30 @@ public class Deliveries extends BaseEntity {
 
     @OneToMany(mappedBy = "delivery", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DeliveryRecords> deliveryRecords = new ArrayList<>();
+
+    public static Deliveries create(
+            UUID orderId,
+            UUID sourceHubId,
+            UUID companyId,
+            String companyAddress,
+            String recipient,
+            String recipientSlackAccount
+    ) {
+        return Deliveries.builder()
+                .orderId(orderId)
+                .sourceHubId(sourceHubId)
+                .companyId(companyId)
+                .status(DeliveryStatusEnum.HUB_WAIT)
+                .companyAddress(companyAddress)
+                .recipient(recipient)
+                .recipientSlackAccount(recipientSlackAccount)
+                .build();
+    }
+
+    public static Deliveries updateSequence(Deliveries delivery, Integer start, Integer end) {
+        delivery.setTotalSequence(end);
+        delivery.setCurrentSeq(start);
+        return delivery;
+    }
 
 }

--- a/logisix/delivery/src/main/java/com/sparta/delivery/entity/DeliveryRecords.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/entity/DeliveryRecords.java
@@ -2,6 +2,10 @@ package com.sparta.delivery.entity;
 
 import com.sparta.delivery.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.math.BigDecimal;
@@ -9,6 +13,10 @@ import java.time.Duration;
 import java.util.UUID;
 
 @Entity(name = "p_delivery_records")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
 public class DeliveryRecords extends BaseEntity {
 
     @Id
@@ -47,5 +55,24 @@ public class DeliveryRecords extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "deliverer_id")
     private Deliverers deliverer;
+
+    public static DeliveryRecords create(
+            UUID departures,
+            UUID arrival,
+            Integer sequence,
+            Duration estimatedTime,
+            BigDecimal estimatedDist,
+            Deliveries delivery
+    ) {
+        return DeliveryRecords.builder()
+                .departures(departures)
+                .arrival(arrival)
+                .status(DeliveryRecordsStatusEnum.WAIT)
+                .sequence(sequence)
+                .estimatedTime(estimatedTime)
+                .estimatedDist(estimatedDist)
+                .delivery(delivery)
+                .build();
+    }
 
 }

--- a/logisix/delivery/src/main/java/com/sparta/delivery/entity/Point.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/entity/Point.java
@@ -1,0 +1,21 @@
+package com.sparta.delivery.entity;
+
+import java.math.BigDecimal;
+
+public class Point {
+    private final BigDecimal longitude;
+    private final BigDecimal latitude;
+
+    public Point(BigDecimal longitude, BigDecimal latitude) {
+        this.longitude = longitude;
+        this.latitude = latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+}

--- a/logisix/delivery/src/main/java/com/sparta/delivery/service/DeliveryService.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/service/DeliveryService.java
@@ -4,12 +4,13 @@ import com.sparta.delivery.common.ApiResponse;
 import com.sparta.delivery.dto.CreateDeliveryRequest;
 import com.sparta.delivery.dto.HubRoute;
 import com.sparta.delivery.entity.Point;
-import com.sparta.delivery.dto.KakaoRouteResponse;
 import com.sparta.delivery.entity.Deliveries;
 import com.sparta.delivery.entity.DeliveryRecords;
 import com.sparta.delivery.repository.DeliveriesJpaRepository;
 import com.sparta.delivery.repository.DeliveryRecordsJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -27,42 +28,60 @@ public class DeliveryService {
     private final DeliveriesJpaRepository deliveryJpaRepository;
     private final DeliveryRecordsJpaRepository deliveryRecordsJpaRepository;
 
+    private static final Logger logger = LoggerFactory.getLogger(DeliveryService.class);
+
+
     // 배송 생성
     public ApiResponse createDelivery(CreateDeliveryRequest request) {
-        // 사용자 권한 및 유효성 체크, 수신인 조회
-        String recipient = "tempRecipient";
-        String recipientSlackAccount = "tempRecipientSlackAccount";
 
-        // 업체 조회
-        String companyAddress = "tempCompanyAdress";
-        Point companyLocation = new Point(BigDecimal.valueOf(127.1058342), BigDecimal.valueOf(37.359708));
-        // 업체가 소속된 허브를 종착 허브로 설정
+        try {
+            // 사용자 유효성 체크
 
-        // 배송 생성
-        Deliveries delivery = Deliveries.create(
+            Deliveries delivery = createDeliveryEntity(request);
+
+            // Redis에서 경로 데이터 가져오기
+            List<HubRoute> hubRoutes = pathService.getHubRoutes();
+
+            // 없을 경우 DB에서 가져오기
+
+            // 최단 경로 생성
+            List<DeliveryRecords> deliveryRecordsList = createDeliveryRecords(request, hubRoutes, delivery);
+
+            // 마지막 허브에서 업체까지의 경로 추가
+            addFinalDeliveryRecord(deliveryRecordsList, delivery);
+
+            // 배송 데이터 저장
+            saveDelivery(delivery, deliveryRecordsList);
+
+            return new ApiResponse<>(200, "배송 생성 성공", null);
+        } catch (Exception e) {
+            logger.error("Error occurred while creating delivery: {}", e.getMessage(), e);
+            return new ApiResponse<>(500, "배송 생성 실패", null);
+        }
+    }
+
+    private Deliveries createDeliveryEntity(CreateDeliveryRequest request) {
+        return Deliveries.create(
                 request.orderId(),
                 request.sourceHubId(),
                 request.destinationId(),
-                companyAddress,
-                recipient,
-                recipientSlackAccount
+                "tempCompanyAddress",
+                "tempRecipient",
+                "tempRecipientSlackAccount"
         );
-        // Redis에서 허브 경로 데이터 가져오기
-        List<HubRoute> hubRoutes = pathService.getHubRoutes();
+    }
 
-//        if(hubRoutes == null) {
-//            // 경로 데이터 없을 경우 DB에서 조회 필요
-//        }
-        // 배송 상세 경로 생성
+    private List<DeliveryRecords> createDeliveryRecords(CreateDeliveryRequest request, List<HubRoute> hubRoutes, Deliveries delivery) {
         List<UUID> paths = pathService.findShortestPath(hubRoutes, request.sourceHubId(), request.destinationId());
         List<DeliveryRecords> deliveryRecordsList = new ArrayList<>();
-        for (int i = 0; i < paths.size() - 1; i ++) {
+
+        for (int i = 0; i < paths.size() - 1; i++) {
             UUID departureHubId = paths.get(i);
             UUID arrivalHubId = paths.get(i + 1);
 
             HubRoute hubRoute = pathService.findHubRoute(hubRoutes, departureHubId, arrivalHubId);
 
-            DeliveryRecords deliverRecord = DeliveryRecords.create(
+            DeliveryRecords deliveryRecord = DeliveryRecords.create(
                     departureHubId,
                     arrivalHubId,
                     i + 1,
@@ -70,41 +89,43 @@ public class DeliveryService {
                     BigDecimal.valueOf(hubRoute.estimatedDistance()),
                     delivery
             );
-            deliveryRecordsList.add(deliverRecord);
+            deliveryRecordsList.add(deliveryRecord);
         }
-        // 마지막 허브 위치 조회
-        Point lastHubLocation = new Point(BigDecimal.valueOf(126.977969), BigDecimal.valueOf(37.566535));
-
-        // 업체까지의 배송 경로 레코드 생성
-        KakaoRouteResponse response = kakaoMapService.getRoute(lastHubLocation, companyLocation);
-        if(response != null && response.routes().length >0) {
-            BigDecimal distance = response.routes()[0].summary().distance();
-            BigDecimal duration = response.routes()[0].summary().duration();
-            DeliveryRecords finalRecord = DeliveryRecords.create(
-                    paths.get(paths.size() - 1),
-                    request.destinationId(),
-                    deliveryRecordsList.size() + 1,
-                    Duration.ofMillis(duration.longValue()),
-                    distance,
-                    delivery
-            );
-            deliveryRecordsList.add(finalRecord);
-        }
-
-        // 시퀀스 업데이트
-        Deliveries updatedDelivery = Deliveries.updateSequence(delivery, 0, deliveryRecordsList.size());
-
-        // 배송 저장
-        deliveryJpaRepository.save(updatedDelivery);
-
-        // 배송 상세 경로 저장
-        deliveryRecordsJpaRepository.saveAll(deliveryRecordsList);
-
-        // 슬랙 메시지 전송
-
-        // 반환
-        return new ApiResponse<>(200, "배송 생성 성공", null);
+        return deliveryRecordsList;
     }
 
+    private void addFinalDeliveryRecord(List<DeliveryRecords> deliveryRecordsList, Deliveries delivery) {
+        Point lastHubLocation = new Point(BigDecimal.valueOf(126.977969), BigDecimal.valueOf(37.566535));
+        Point companyLocation = new Point(BigDecimal.valueOf(127.1058342), BigDecimal.valueOf(37.359708));
+
+        kakaoMapService.getRouteAsync(lastHubLocation, companyLocation)
+                .thenAccept(response -> {
+                    if (response != null && response.routes().length > 0) {
+                        BigDecimal distance = response.routes()[0].summary().distance();
+                        BigDecimal duration = response.routes()[0].summary().duration();
+                        DeliveryRecords finalRecord = DeliveryRecords.create(
+                                deliveryRecordsList.get(deliveryRecordsList.size() - 1).getArrival(),
+                                delivery.getCompanyId(),
+                                deliveryRecordsList.size() + 1,
+                                Duration.ofMillis(duration.longValue()),
+                                distance,
+                                delivery
+                        );
+                        deliveryRecordsList.add(finalRecord);
+                    } else {
+                        logger.warn("유효한 경로가 없음");
+                    }
+                }).exceptionally(e -> {
+                    logger.error("addFinalDeliveryRecord failed: {}", e.getMessage(), e);
+                    return null;
+                });
+    }
+
+    private void saveDelivery(Deliveries delivery, List<DeliveryRecords> deliveryRecordsList) {
+        delivery.setTotalSequence(deliveryRecordsList.size());
+        delivery.setCurrentSeq(0);
+        deliveryJpaRepository.save(delivery);
+        deliveryRecordsJpaRepository.saveAll(deliveryRecordsList);
+    }
 
 }

--- a/logisix/delivery/src/main/java/com/sparta/delivery/service/DeliveryService.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/service/DeliveryService.java
@@ -1,0 +1,110 @@
+package com.sparta.delivery.service;
+
+import com.sparta.delivery.common.ApiResponse;
+import com.sparta.delivery.dto.CreateDeliveryRequest;
+import com.sparta.delivery.dto.HubRoute;
+import com.sparta.delivery.entity.Point;
+import com.sparta.delivery.dto.KakaoRouteResponse;
+import com.sparta.delivery.entity.Deliveries;
+import com.sparta.delivery.entity.DeliveryRecords;
+import com.sparta.delivery.repository.DeliveriesJpaRepository;
+import com.sparta.delivery.repository.DeliveryRecordsJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryService {
+
+    private final PathService pathService;
+    private final KakaoMapService kakaoMapService;
+    private final DeliveriesJpaRepository deliveryJpaRepository;
+    private final DeliveryRecordsJpaRepository deliveryRecordsJpaRepository;
+
+    // 배송 생성
+    public ApiResponse createDelivery(CreateDeliveryRequest request) {
+        // 사용자 권한 및 유효성 체크, 수신인 조회
+        String recipient = "tempRecipient";
+        String recipientSlackAccount = "tempRecipientSlackAccount";
+
+        // 업체 조회
+        String companyAddress = "tempCompanyAdress";
+        Point companyLocation = new Point(BigDecimal.valueOf(127.1058342), BigDecimal.valueOf(37.359708));
+        // 업체가 소속된 허브를 종착 허브로 설정
+
+        // 배송 생성
+        Deliveries delivery = Deliveries.create(
+                request.orderId(),
+                request.sourceHubId(),
+                request.destinationId(),
+                companyAddress,
+                recipient,
+                recipientSlackAccount
+        );
+        // Redis에서 허브 경로 데이터 가져오기
+        List<HubRoute> hubRoutes = pathService.getHubRoutes();
+
+//        if(hubRoutes == null) {
+//            // 경로 데이터 없을 경우 DB에서 조회 필요
+//        }
+        // 배송 상세 경로 생성
+        List<UUID> paths = pathService.findShortestPath(hubRoutes, request.sourceHubId(), request.destinationId());
+        List<DeliveryRecords> deliveryRecordsList = new ArrayList<>();
+        for (int i = 0; i < paths.size() - 1; i ++) {
+            UUID departureHubId = paths.get(i);
+            UUID arrivalHubId = paths.get(i + 1);
+
+            HubRoute hubRoute = pathService.findHubRoute(hubRoutes, departureHubId, arrivalHubId);
+
+            DeliveryRecords deliverRecord = DeliveryRecords.create(
+                    departureHubId,
+                    arrivalHubId,
+                    i + 1,
+                    hubRoute.estimateTime(),
+                    BigDecimal.valueOf(hubRoute.estimatedDistance()),
+                    delivery
+            );
+            deliveryRecordsList.add(deliverRecord);
+        }
+        // 마지막 허브 위치 조회
+        Point lastHubLocation = new Point(BigDecimal.valueOf(126.977969), BigDecimal.valueOf(37.566535));
+
+        // 업체까지의 배송 경로 레코드 생성
+        KakaoRouteResponse response = kakaoMapService.getRoute(lastHubLocation, companyLocation);
+        if(response != null && response.routes().length >0) {
+            BigDecimal distance = response.routes()[0].summary().distance();
+            BigDecimal duration = response.routes()[0].summary().duration();
+            DeliveryRecords finalRecord = DeliveryRecords.create(
+                    paths.get(paths.size() - 1),
+                    request.destinationId(),
+                    deliveryRecordsList.size() + 1,
+                    Duration.ofMillis(duration.longValue()),
+                    distance,
+                    delivery
+            );
+            deliveryRecordsList.add(finalRecord);
+        }
+
+        // 시퀀스 업데이트
+        Deliveries updatedDelivery = Deliveries.updateSequence(delivery, 0, deliveryRecordsList.size());
+
+        // 배송 저장
+        deliveryJpaRepository.save(updatedDelivery);
+
+        // 배송 상세 경로 저장
+        deliveryRecordsJpaRepository.saveAll(deliveryRecordsList);
+
+        // 슬랙 메시지 전송
+
+        // 반환
+        return new ApiResponse<>(200, "배송 생성 성공", null);
+    }
+
+
+}

--- a/logisix/delivery/src/main/java/com/sparta/delivery/service/KakaoMapService.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/service/KakaoMapService.java
@@ -1,0 +1,45 @@
+package com.sparta.delivery.service;
+
+import com.sparta.delivery.dto.KakaoRouteResponse;
+import com.sparta.delivery.entity.Point;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+
+@Service
+public class KakaoMapService {
+
+    @Value("${kakao.api.key}")
+    private String KAKAO_API_KEY;
+    private static final String DIRECTIONS_URL = "https://apis-navi.kakaomobility.com/v1/directions";
+
+    public KakaoRouteResponse getRoute(Point origin, Point destination) {
+        // 요청 URL 생성
+        String url = UriComponentsBuilder.fromUriString(DIRECTIONS_URL)
+                .queryParam("origin", origin.getLongitude() + "," + origin.getLatitude())
+                .queryParam("destination", destination.getLongitude() + "," + destination.getLatitude())
+                .queryParam("priority", "SHORTEST")
+                .toUriString();
+
+        // HTTP 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "KakaoAK " + KAKAO_API_KEY);
+
+        // API 호출
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<KakaoRouteResponse> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                new org.springframework.http.HttpEntity<>(headers),
+                KakaoRouteResponse.class
+        );
+
+        return response.getBody();
+    }
+
+}

--- a/logisix/delivery/src/main/java/com/sparta/delivery/service/PathService.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/service/PathService.java
@@ -1,0 +1,119 @@
+package com.sparta.delivery.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.delivery.dto.HubRoute;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class PathService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    // Redis에서 허브 경로 데이터 가져오기
+    public List<HubRoute> getHubRoutes() {
+        try {
+            String hubRoutesJson = redisTemplate.opsForValue().get("hub_routes");
+            if (Objects.isNull(hubRoutesJson)) {
+                return null;
+            }
+            return objectMapper.readValue(hubRoutesJson, new TypeReference<>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("레디스 조회 실패", e);
+        }
+    }
+
+    // 시작 허브부터 종착 허브까지 최단 경로 찾기
+    public List<UUID> findShortestPath(List<HubRoute> hubRoutes, UUID startHubId, UUID endHubId) {
+
+        // 그래프 구성
+        Map<UUID, List<HubRoute>> graph = buildGraph(hubRoutes);
+
+        return dijkstra(graph, startHubId, endHubId);
+    }
+
+    private Map<UUID, List<HubRoute>> buildGraph(List<HubRoute> hubRoutes) {
+        Map<UUID, List<HubRoute>> graph = new HashMap<>();
+        for (HubRoute route : hubRoutes) {
+            graph.computeIfAbsent(route.departureHubId(), k -> new ArrayList<>()).add(route);
+        }
+        return graph;
+    }
+
+    private List<UUID> dijkstra(Map<UUID, List<HubRoute>> graph, UUID startHubId, UUID endHubId) {
+        // 우선순위 큐 (최단 시간 기준)
+        PriorityQueue<Node> queue = new PriorityQueue<>(Comparator.comparing(Node::totalTime));
+        Map<UUID, Duration> shortestTimes = new HashMap<>();
+        Map<UUID, UUID> previousNodes = new HashMap<>();
+
+        // 초기화
+        queue.add(new Node(startHubId, Duration.ZERO));
+        shortestTimes.put(startHubId, Duration.ZERO);
+
+        while (!queue.isEmpty()) {
+            Node currentNode = queue.poll();
+            UUID currentHubId = currentNode.hubId();
+
+            // 종착 허브에 도달하면 경로 복원
+            if (currentHubId.equals(endHubId)) {
+                return reconstructPath(previousNodes, endHubId);
+            }
+
+            // 인접 허브 탐색
+            List<HubRoute> neighbors = graph.getOrDefault(currentHubId, Collections.emptyList());
+            for (HubRoute route : neighbors) {
+                UUID neighborHubId = route.arrivalHubId();
+                Duration newTime = currentNode.totalTime().plus(route.estimateTime());
+
+                if (newTime.compareTo(shortestTimes.getOrDefault(neighborHubId, Duration.ofDays(Long.MAX_VALUE))) < 0) {
+                    shortestTimes.put(neighborHubId, newTime);
+                    previousNodes.put(neighborHubId, currentHubId);
+                    queue.add(new Node(neighborHubId, newTime));
+                }
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<UUID> reconstructPath(Map<UUID, UUID> previousNodes, UUID endHubId) {
+        List<UUID> path = new LinkedList<>();
+        for (UUID at = endHubId; at != null; at = previousNodes.get(at)) {
+            path.add(0, at);
+        }
+        return path;
+    }
+
+    private static class Node {
+        private final UUID hubId;
+        private final Duration totalTime;
+
+        public Node(UUID hubId, Duration totalTime) {
+            this.hubId = hubId;
+            this.totalTime = totalTime;
+        }
+
+        public UUID hubId() {
+            return hubId;
+        }
+
+        public Duration totalTime() {
+            return totalTime;
+        }
+    }
+
+    public HubRoute findHubRoute(List<HubRoute> hubRoutes, UUID departureHubId, UUID arrivalHubId) {
+        return hubRoutes.stream()
+                .filter(route -> route.departureHubId().equals(departureHubId) && route.arrivalHubId().equals(arrivalHubId))
+                .findFirst()
+                .orElse(null);
+    }
+
+}

--- a/logisix/delivery/src/main/java/com/sparta/delivery/service/PathService.java
+++ b/logisix/delivery/src/main/java/com/sparta/delivery/service/PathService.java
@@ -85,8 +85,8 @@ public class PathService {
 
     private List<UUID> reconstructPath(Map<UUID, UUID> previousNodes, UUID endHubId) {
         List<UUID> path = new LinkedList<>();
-        for (UUID at = endHubId; at != null; at = previousNodes.get(at)) {
-            path.add(0, at);
+        for (UUID arrival = endHubId; arrival != null; arrival = previousNodes.get(arrival)) {
+            path.add(0, arrival);
         }
         return path;
     }

--- a/logisix/docker-compose.yml
+++ b/logisix/docker-compose.yml
@@ -153,8 +153,6 @@ services:
       - "5437:5432"
     networks:
       - app-network
-    networks:
-      - app-network
 
   slack-service:
     image: slack-service:latest


### PR DESCRIPTION
# [Feat] 배송 생성 기능

## 개요
배송 생성 기능을 구현합니다

## 변경 사항
- delivery-service network 정의 중복 코드 삭제
- redis 의존성 추가
- 카카오맵 api 경로찾기 기능 구현
- 배송 최단시간 경로 탐색 기능 구현
- 배송 생성 로직 세분화
- 카카오맵 API 호출 비동기 방식 처리

## 스크린샷 (선택사항)


## 특이 사항
- 다른 서비스랑 연동하는 부분은 아직 구현하지 않았습니다. 타 기능 개발 후 추가하겠습니다.

resolves: #40 