### PR TITLE
[Feat] 배송 생성 기능

### DIFF
--- a/delivery/build.gradle
+++ b/delivery/build.gradle
@@ -20,7 +20,6 @@ configurations {
 }
 
 repositories {
-	mavenLocal()
 	mavenCentral()
 }
 
@@ -36,6 +35,7 @@ dependencies {
 	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 	implementation 'io.github.openfeign:feign-micrometer'
 	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 //	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	compileOnly 'org.projectlombok:lombok'
@@ -43,7 +43,6 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation project(':common')
 }
 
 dependencyManagement {

--- a/delivery/src/main/java/com/sparta/delivery/config/ObjectMapperConfig.java
+++ b/delivery/src/main/java/com/sparta/delivery/config/ObjectMapperConfig.java
@@ -1,0 +1,14 @@
+package com.sparta.delivery.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/delivery/src/main/java/com/sparta/delivery/controller/DeliveryController.java
+++ b/delivery/src/main/java/com/sparta/delivery/controller/DeliveryController.java
@@ -1,0 +1,25 @@
+package com.sparta.delivery.controller;
+
+import com.sparta.delivery.common.ApiResponse;
+import com.sparta.delivery.dto.CreateDeliveryRequest;
+import com.sparta.delivery.service.DeliveryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/deliveries")
+public class DeliveryController {
+
+    private final DeliveryService deliveryService;
+
+    @PostMapping
+    public ApiResponse<Void> createDelivery(
+            @RequestBody CreateDeliveryRequest request
+    ) {
+        return deliveryService.createDelivery(request);
+    }
+}

--- a/delivery/src/main/java/com/sparta/delivery/dto/CreateDeliveryRequest.java
+++ b/delivery/src/main/java/com/sparta/delivery/dto/CreateDeliveryRequest.java
@@ -2,10 +2,17 @@ package com.sparta.delivery.dto;
 
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record CreateDeliveryRequest(
         @NotNull UUID orderId,
         @NotNull UUID sourceHubId,
-        @NotNull UUID destinationId
-        ) { }
+        @NotNull UUID destinationId,
+        @NotNull String companyAddress,
+        @NotNull String recipient,
+        @NotNull String recipientSlackAccount,
+        @NotNull UUID companyId,
+
+        @NotNull LocalDateTime deliverDate
+) { }

--- a/delivery/src/main/java/com/sparta/delivery/dto/CreateDeliveryRequest.java
+++ b/delivery/src/main/java/com/sparta/delivery/dto/CreateDeliveryRequest.java
@@ -1,0 +1,11 @@
+package com.sparta.delivery.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record CreateDeliveryRequest(
+        @NotNull UUID orderId,
+        @NotNull UUID sourceHubId,
+        @NotNull UUID destinationId
+        ) { }

--- a/delivery/src/main/java/com/sparta/delivery/dto/HubRoute.java
+++ b/delivery/src/main/java/com/sparta/delivery/dto/HubRoute.java
@@ -1,0 +1,14 @@
+package com.sparta.delivery.dto;
+
+import java.time.Duration;
+import java.util.UUID;
+
+
+public record HubRoute(
+        UUID hubRouteId,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        double estimatedDistance,
+        Duration estimateTime
+) {
+}

--- a/delivery/src/main/java/com/sparta/delivery/dto/KakaoRouteResponse.java
+++ b/delivery/src/main/java/com/sparta/delivery/dto/KakaoRouteResponse.java
@@ -1,0 +1,23 @@
+package com.sparta.delivery.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.math.BigDecimal;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoRouteResponse(
+        Route[] routes
+    ) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Route(
+            Summary summary
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Summary(
+            BigDecimal distance,
+            BigDecimal duration
+    ) {
+    }
+}

--- a/delivery/src/main/java/com/sparta/delivery/entity/Deliveries.java
+++ b/delivery/src/main/java/com/sparta/delivery/entity/Deliveries.java
@@ -40,7 +40,7 @@ public class Deliveries extends BaseEntity {
     @Column(nullable = false)
     private String recipientSlackAccount;
 
-    //    @Column(nullable = false)
+    @Column(nullable = false)
     private LocalDateTime dispatchDeadline;
 
     private Integer totalSequence;

--- a/delivery/src/main/java/com/sparta/delivery/entity/Deliveries.java
+++ b/delivery/src/main/java/com/sparta/delivery/entity/Deliveries.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 @Getter
+@Setter
 public class Deliveries extends BaseEntity {
 
     @Id
@@ -39,7 +40,7 @@ public class Deliveries extends BaseEntity {
     @Column(nullable = false)
     private String recipientSlackAccount;
 
-    @Column(nullable = false)
+    //    @Column(nullable = false)
     private LocalDateTime dispatchDeadline;
 
     private Integer totalSequence;
@@ -54,5 +55,24 @@ public class Deliveries extends BaseEntity {
 
     @OneToMany(mappedBy = "delivery", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DeliveryRecords> deliveryRecords = new ArrayList<>();
+
+    public static Deliveries create(
+            UUID orderId,
+            UUID sourceHubId,
+            UUID companyId,
+            String companyAddress,
+            String recipient,
+            String recipientSlackAccount
+    ) {
+        return Deliveries.builder()
+                .orderId(orderId)
+                .sourceHubId(sourceHubId)
+                .companyId(companyId)
+                .status(DeliveryStatusEnum.HUB_WAIT)
+                .companyAddress(companyAddress)
+                .recipient(recipient)
+                .recipientSlackAccount(recipientSlackAccount)
+                .build();
+    }
 
 }

--- a/delivery/src/main/java/com/sparta/delivery/entity/DeliveryRecords.java
+++ b/delivery/src/main/java/com/sparta/delivery/entity/DeliveryRecords.java
@@ -2,6 +2,10 @@ package com.sparta.delivery.entity;
 
 import com.sparta.delivery.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.math.BigDecimal;
@@ -9,6 +13,10 @@ import java.time.Duration;
 import java.util.UUID;
 
 @Entity(name = "p_delivery_records")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
 public class DeliveryRecords extends BaseEntity {
 
     @Id
@@ -47,5 +55,24 @@ public class DeliveryRecords extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "deliverer_id")
     private Deliverers deliverer;
+
+    public static DeliveryRecords create(
+            UUID departures,
+            UUID arrival,
+            Integer sequence,
+            Duration estimatedTime,
+            BigDecimal estimatedDist,
+            Deliveries delivery
+    ) {
+        return DeliveryRecords.builder()
+                .departures(departures)
+                .arrival(arrival)
+                .status(DeliveryRecordsStatusEnum.WAIT)
+                .sequence(sequence)
+                .estimatedTime(estimatedTime)
+                .estimatedDist(estimatedDist)
+                .delivery(delivery)
+                .build();
+    }
 
 }

--- a/delivery/src/main/java/com/sparta/delivery/service/DeliveryService.java
+++ b/delivery/src/main/java/com/sparta/delivery/service/DeliveryService.java
@@ -1,0 +1,131 @@
+package com.sparta.delivery.service;
+
+import com.sparta.delivery.common.ApiResponse;
+import com.sparta.delivery.dto.CreateDeliveryRequest;
+import com.sparta.delivery.dto.HubRoute;
+import com.sparta.delivery.entity.Deliveries;
+import com.sparta.delivery.entity.DeliveryRecords;
+import com.sparta.delivery.util.Point;
+import com.sparta.delivery.repository.DeliveriesJpaRepository;
+import com.sparta.delivery.repository.DeliveryRecordsJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryService {
+
+    private final PathService pathService;
+    private final KakaoMapService kakaoMapService;
+    private final DeliveriesJpaRepository deliveryJpaRepository;
+    private final DeliveryRecordsJpaRepository deliveryRecordsJpaRepository;
+
+    private static final Logger logger = LoggerFactory.getLogger(DeliveryService.class);
+
+
+    // 배송 생성
+    public ApiResponse<Void> createDelivery(CreateDeliveryRequest request) {
+
+        try {
+            // 사용자 유효성 체크
+
+            Deliveries delivery = createDeliveryEntity(request);
+
+            // Redis에서 경로 데이터 가져오기
+            List<HubRoute> hubRoutes = pathService.getHubRoutes();
+
+            // 없을 경우 DB에서 가져오기
+
+            // 최단 경로 생성
+            List<DeliveryRecords> deliveryRecordsList = createDeliveryRecords(request, hubRoutes, delivery);
+
+            // 마지막 허브에서 업체까지의 경로 추가
+            addFinalDeliveryRecord(deliveryRecordsList, delivery);
+
+            // 배송 데이터 저장
+            saveDelivery(delivery, deliveryRecordsList);
+
+            return new ApiResponse<>(200, "배송 생성 성공", null);
+        } catch (Exception e) {
+            logger.error("Error occurred while creating delivery: {}", e.getMessage(), e);
+            return new ApiResponse<>(500, "배송 생성 실패", null);
+        }
+    }
+
+    private Deliveries createDeliveryEntity(CreateDeliveryRequest request) {
+        return Deliveries.create(
+                request.orderId(),
+                request.sourceHubId(),
+                request.destinationId(),
+                "tempCompanyAddress",
+                "tempRecipient",
+                "tempRecipientSlackAccount"
+        );
+    }
+
+    private List<DeliveryRecords> createDeliveryRecords(CreateDeliveryRequest request, List<HubRoute> hubRoutes, Deliveries delivery) {
+        List<UUID> paths = pathService.findShortestPath(hubRoutes, request.sourceHubId(), request.destinationId());
+        List<DeliveryRecords> deliveryRecordsList = new ArrayList<>();
+
+        for (int i = 0; i < paths.size() - 1; i++) {
+            UUID departureHubId = paths.get(i);
+            UUID arrivalHubId = paths.get(i + 1);
+
+            HubRoute hubRoute = pathService.findHubRoute(hubRoutes, departureHubId, arrivalHubId);
+
+            DeliveryRecords deliveryRecord = DeliveryRecords.create(
+                    departureHubId,
+                    arrivalHubId,
+                    i + 1,
+                    hubRoute.estimateTime(),
+                    BigDecimal.valueOf(hubRoute.estimatedDistance()),
+                    delivery
+            );
+            deliveryRecordsList.add(deliveryRecord);
+        }
+        return deliveryRecordsList;
+    }
+
+    private void addFinalDeliveryRecord(List<DeliveryRecords> deliveryRecordsList, Deliveries delivery) {
+        Point lastHubLocation = new Point(BigDecimal.valueOf(126.977969), BigDecimal.valueOf(37.566535));
+        Point companyLocation = new Point(BigDecimal.valueOf(127.1058342), BigDecimal.valueOf(37.359708));
+
+        kakaoMapService.getRouteAsync(lastHubLocation, companyLocation)
+                .thenAccept(response -> {
+                    if (response != null && response.routes().length > 0) {
+                        BigDecimal distance = response.routes()[0].summary().distance();
+                        BigDecimal duration = response.routes()[0].summary().duration();
+                        DeliveryRecords finalRecord = DeliveryRecords.create(
+                                deliveryRecordsList.get(deliveryRecordsList.size() - 1).getArrival(),
+                                delivery.getCompanyId(),
+                                deliveryRecordsList.size() + 1,
+                                Duration.ofMillis(duration.longValue()),
+                                distance,
+                                delivery
+                        );
+                        deliveryRecordsList.add(finalRecord);
+                    } else {
+                        logger.warn("유효한 경로가 없음");
+                    }
+                }).exceptionally(e -> {
+                    logger.error("addFinalDeliveryRecord failed: {}", e.getMessage(), e);
+                    return null;
+                });
+    }
+
+    private void saveDelivery(Deliveries delivery, List<DeliveryRecords> deliveryRecordsList) {
+        delivery.setTotalSequence(deliveryRecordsList.size());
+        delivery.setCurrentSeq(0);
+        deliveryJpaRepository.save(delivery);
+        deliveryRecordsJpaRepository.saveAll(deliveryRecordsList);
+    }
+
+}

--- a/delivery/src/main/java/com/sparta/delivery/service/KakaoMapService.java
+++ b/delivery/src/main/java/com/sparta/delivery/service/KakaoMapService.java
@@ -1,0 +1,54 @@
+package com.sparta.delivery.service;
+
+import com.sparta.delivery.dto.KakaoRouteResponse;
+import com.sparta.delivery.util.Point;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.concurrent.CompletableFuture;
+
+
+@Service
+public class KakaoMapService {
+
+    @Value("${kakao.api.key}")
+    private String kakaoApiKey;
+
+    @Async
+    public CompletableFuture<KakaoRouteResponse> getRouteAsync(Point origin, Point destination) {
+        try {
+            String url = UriComponentsBuilder.newInstance()
+                    .scheme("https")
+                    .host("apis-navi.kakaomobility.com")
+                    .path("/v1/directions")
+                    .queryParam("origin", origin.getLongitude() + "," + origin.getLatitude())
+                    .queryParam("destination", destination.getLongitude() + "," + destination.getLatitude())
+                    .queryParam("priority", "SHORTEST")
+                    .build()
+                    .toUriString();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "KakaoAK " + kakaoApiKey);
+
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<KakaoRouteResponse> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    new HttpEntity<>(headers),
+                    KakaoRouteResponse.class
+            );
+
+            return CompletableFuture.completedFuture(response.getBody());
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+}

--- a/delivery/src/main/java/com/sparta/delivery/service/PathService.java
+++ b/delivery/src/main/java/com/sparta/delivery/service/PathService.java
@@ -1,0 +1,119 @@
+package com.sparta.delivery.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.delivery.dto.HubRoute;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class PathService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    // Redis에서 허브 경로 데이터 가져오기
+    public List<HubRoute> getHubRoutes() {
+        try {
+            String hubRoutesJson = redisTemplate.opsForValue().get("hub_routes");
+            if (Objects.isNull(hubRoutesJson)) {
+                return null;
+            }
+            return objectMapper.readValue(hubRoutesJson, new TypeReference<>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("레디스 조회 실패", e);
+        }
+    }
+
+    // 시작 허브부터 종착 허브까지 최단 경로 찾기
+    public List<UUID> findShortestPath(List<HubRoute> hubRoutes, UUID startHubId, UUID endHubId) {
+
+        // 그래프 구성
+        Map<UUID, List<HubRoute>> graph = buildGraph(hubRoutes);
+
+        return dijkstra(graph, startHubId, endHubId);
+    }
+
+    private Map<UUID, List<HubRoute>> buildGraph(List<HubRoute> hubRoutes) {
+        Map<UUID, List<HubRoute>> graph = new HashMap<>();
+        for (HubRoute route : hubRoutes) {
+            graph.computeIfAbsent(route.departureHubId(), k -> new ArrayList<>()).add(route);
+        }
+        return graph;
+    }
+
+    private List<UUID> dijkstra(Map<UUID, List<HubRoute>> graph, UUID startHubId, UUID endHubId) {
+        // 우선순위 큐 (최단 시간 기준)
+        PriorityQueue<Node> queue = new PriorityQueue<>(Comparator.comparing(Node::totalTime));
+        Map<UUID, Duration> shortestTimes = new HashMap<>();
+        Map<UUID, UUID> previousNodes = new HashMap<>();
+
+        // 초기화
+        queue.add(new Node(startHubId, Duration.ZERO));
+        shortestTimes.put(startHubId, Duration.ZERO);
+
+        while (!queue.isEmpty()) {
+            Node currentNode = queue.poll();
+            UUID currentHubId = currentNode.hubId();
+
+            // 종착 허브에 도달하면 경로 복원
+            if (currentHubId.equals(endHubId)) {
+                return reconstructPath(previousNodes, endHubId);
+            }
+
+            // 인접 허브 탐색
+            List<HubRoute> neighbors = graph.getOrDefault(currentHubId, Collections.emptyList());
+            for (HubRoute route : neighbors) {
+                UUID neighborHubId = route.arrivalHubId();
+                Duration newTime = currentNode.totalTime().plus(route.estimateTime());
+
+                if (newTime.compareTo(shortestTimes.getOrDefault(neighborHubId, Duration.ofDays(Long.MAX_VALUE))) < 0) {
+                    shortestTimes.put(neighborHubId, newTime);
+                    previousNodes.put(neighborHubId, currentHubId);
+                    queue.add(new Node(neighborHubId, newTime));
+                }
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<UUID> reconstructPath(Map<UUID, UUID> previousNodes, UUID endHubId) {
+        List<UUID> path = new LinkedList<>();
+        for (UUID arrival = endHubId; arrival != null; arrival = previousNodes.get(arrival)) {
+            path.add(0, arrival);
+        }
+        return path;
+    }
+
+    private static class Node {
+        private final UUID hubId;
+        private final Duration totalTime;
+
+        public Node(UUID hubId, Duration totalTime) {
+            this.hubId = hubId;
+            this.totalTime = totalTime;
+        }
+
+        public UUID hubId() {
+            return hubId;
+        }
+
+        public Duration totalTime() {
+            return totalTime;
+        }
+    }
+
+    public HubRoute findHubRoute(List<HubRoute> hubRoutes, UUID departureHubId, UUID arrivalHubId) {
+        return hubRoutes.stream()
+                .filter(route -> route.departureHubId().equals(departureHubId) && route.arrivalHubId().equals(arrivalHubId))
+                .findFirst()
+                .orElse(null);
+    }
+
+}

--- a/delivery/src/main/java/com/sparta/delivery/util/Point.java
+++ b/delivery/src/main/java/com/sparta/delivery/util/Point.java
@@ -1,0 +1,21 @@
+package com.sparta.delivery.util;
+
+import java.math.BigDecimal;
+
+public class Point {
+    private final BigDecimal longitude;
+    private final BigDecimal latitude;
+
+    public Point(BigDecimal longitude, BigDecimal latitude) {
+        this.longitude = longitude;
+        this.latitude = latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,8 +90,6 @@ services:
       - "5437:5432"
     networks:
       - app-network
-    networks:
-      - app-network
 
   slack-service:
     image: slack-service:latest


### PR DESCRIPTION
# [Feat] 배송 생성 기능

## 개요
배송 생성 기능을 구현합니다

## 변경 사항
- common 모듈 제거
- redis 추가
- delivery-service network 정의 중복 코드 삭제
- redis 의존성 추가
- 카카오맵 api 경로찾기 기능 구현
- 배송 최단시간 경로 탐색 기능 구현
- 배송 생성 로직 세분화
- 카카오맵 API 호출 비동기 방식 처리

## 스크린샷 (선택사항)
<!-- UI 변경사항을 보여주는 스크린샷 -->

## 특이 사항
- 문제가 많을 것 같습니다. 궁금한점은 바로 물어봐 주세요..
- 레디스 캐싱 후 테스트는 못해봤습니다. 해당 부분 추후에 보강하겠습니다.

- 한번은 기능수정.. 한번은 브랜치 리네임으로 closed 되었습니다. 직전 pr과 같은 내용입니다.

resolves: #40 
